### PR TITLE
Alpha transform fixes

### DIFF
--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -219,6 +219,7 @@ local function formtag(tag, argumentlist)
   if #argumentlist == 1 then
     if type(argstring) == "number" then
       if tag == "alpha" or tag == "1a" or tag == "2a" or tag == "3a" or tag == "4a" then
+        argstring = lnlib.math.clamp(tonumber(argstring), 0, 255)
         return ("\\%s&H%02X&"):format(tag, argstring);
       else
         return ("\\%s%.2f"):format(tag,argstring);

--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -218,7 +218,7 @@ local function formtag(tag, argumentlist)
   
   if #argumentlist == 1 then
     if type(argstring) == "number" then
-      if tag == "alpha" or tag == "a" or tag == "1a" or tag == "2a" or tag == "3a" or tag == "4a" then
+      if tag == "alpha" or tag == "1a" or tag == "2a" or tag == "3a" or tag == "4a" then
         return ("\\%s&H%02X&"):format(tag, argstring);
       else
         return ("\\%s%.2f"):format(tag,argstring);


### PR DESCRIPTION
Clamping alpha values between 0 and 255 is the main point here, the `\a` (old form alignment tag) was very likely unintentionally assumed to be an alpha tag so I fixed that too.