### PR TITLE
Fix modulo arithmetic in noise wave

### DIFF
--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -713,7 +713,7 @@ lnlib = {
             local randomvalues = {}
             math.randomseed(phase)
             for i = 1, wavelength do
-              randomvalues[math.floor(i+phase % wavelength)] = amplitude * (math.random() * 2 - 1)
+              randomvalues[math.floor((i+phase) % wavelength)] = amplitude * (math.random() * 2 - 1)
             end
             table.insert(ftable, {form="noise", w=wavelength,a=amplitude,p=phase, val=randomvalues})
           else
@@ -737,7 +737,7 @@ lnlib = {
             local randomvalues = {}
             math.randomseed(phase)
             for i = 1, wavelength do
-              randomvalues[math.floor(i+phase % wavelength)] = amplitude * (math.random() * 2 - 1)
+              randomvalues[math.floor((i+phase) % wavelength)] = amplitude * (math.random() * 2 - 1)
             end
             table.insert(ftable, {form="noise", w=wavelength,a=amplitude,p=phase, val=randomvalues})
           else


### PR DESCRIPTION
Noise waveform would error with nonzero phase. Sample code:
```
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,code once,ln = _G.require 'ln.kara'; ln.init(tenv)
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,code once,waveZ = ln.wave.new()  waveZ.addFunction(function(t) return 100 end) waveZ.addWave("noise", 200, 3, 5)
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,template syl,!retime("line",-200,200)!{\an5\fade(200,200)!ln.tag.pos()!\shad0\blur5\1c&HFFFFFF&\3c&HFFFFFF&!ln.wave.transform(waveZ, "fscy", nil, nil, syl.i*(1000/10), 5)!}
Comment: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,karaoke,Test line ABCDE
```
Produces error:
```
Runtime error in template expression: [string "<redacted>"]:759: attempt to perform arithmetic on a nil value
Expression producing error: ln.wave.transform(waveZ, "fscy", nil, nil, syl.i*(1000/10), 5)
Template with expression: !retime("line",-200,200)!{\an5\fade(200,200)!ln.tag.pos()!\shad0\blur5\1c&HFFFFFF&\3c&HFFFFFF&!ln.wave.transform(waveZ, "fscy", nil, nil, syl.i*(1000/10), 5)!}```