### PR TITLE
Wave init utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,26 @@ Example: ```!waveX.addFunction(function(t) return _G.math.random()*2-1 end)!``` 
 
 ---
 
+	waveX.addConstant(c)
+
+Adds a constant value to the wave function. Shorthand for ```waveX.addFunction(function() return c end)```, convenient for centering alpha or colors in the 0..255 range.
+
+---
+
+	waveX.clear()
+
+Removes all previously registered waveforms/functions from the wave table.
+
+---
+
+	waveX.setWave(...)
+	waveX.setFunction(func)
+	waveX.setConstant(c)
+
+Clears the wave table, then adds the corresponding component.
+
+---
+
 	waveX.getValue(time) -> number
 	
 Gets the value of the wave function at ```time```.

--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -709,9 +709,9 @@ lnlib = {
   },
 
   wave = {
-    new = function()
+    new = function(...)
       local ftable = {}
-      return {
+      local self = {
         addWave = function(waveform, wavelength, amplitude, phase)
           amplitude = amplitude or 1
           phase = phase or 0
@@ -730,6 +730,11 @@ lnlib = {
 
         addFunction = function(func)
           table.insert(ftable, {form="function", f = func})
+          return ""
+        end,
+
+        addConstant = function(c)
+          table.insert(ftable, {form="function", f = function() return c end})
           return ""
         end,
 
@@ -778,6 +783,12 @@ lnlib = {
           return y
         end
       }
+
+      if #arg > 0 then
+        self.addWave(unpack(arg))
+      end
+
+      return self
     end,
 
     transform = function(wave, tags, starttime, endtime, delay, framestep, jumpToStartingPosition, argY, argZ)

--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -744,6 +744,8 @@ lnlib = {
 
         setWave = function(waveform, wavelength, amplitude, phase)
           cleartable(ftable)
+          amplitude = amplitude or 1
+          phase = phase or 0
           if waveform == "noise" or waveform == "random" then
             local randomvalues = {}
             math.randomseed(phase)
@@ -760,6 +762,12 @@ lnlib = {
         setFunction = function(func)
           cleartable(ftable)
           table.insert(ftable, {form="function", f = func})
+          return ""
+        end,
+
+        setConstant = function(c)
+          cleartable(ftable)
+          table.insert(ftable, {form="function", f = function() return c end})
           return ""
         end,
 


### PR DESCRIPTION
Provides a few shorthands for creating new waves:
```
waveX = ln.wave.new()
waveX.addWave('sine', 1500, 64, 0)
waveX.addFunction(function() return 100 end)
```
can be shortened into:
```
waveX = ln.wave.new('sine', 1500, 64, 0)
waveX.addConstant(100)
```

Also adds missing documentation for `wave.clear()` and the `wave.setXXX` family of methods