### PR TITLE
Change "line" to "lsyl" kara mode in `ln.tag.move`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If a table is passed as the first argument, all arguments will be read from ther
 
 ---
 
-    ln.tag.move(xoff0, yoff0, xoff1, yoff1, time0, time1, alignment, anchorpoint, line_kara_mode) -> string
+    ln.tag.move(xoff0, yoff0, xoff1, yoff1, time0, time1, alignment, anchorpoint, lsyl_mode) -> string
     ln.tag.move(table) -> string
 	
 Creates \an and \move tags. 
@@ -200,7 +200,7 @@ Creates \an and \move tags.
 `time0` and `time1` are the times put in the \move tag and work as you'd expect. Leaving these arguments out will also leave them out of the tag, causing the move to occur over the whole duration of the line.\
 `alignment` is what this sets the \an tag to. Defaults to the alignment defined in the line's style.\
 `anchorpoint` defines the alignment value used for calculating the base position. Defaults to the same as the `alignment` argument, or the alignment defined in the line's style. For example, `anchorpoint=3` will calculate the bottom right of the text as the base position.\
-`line_kara_mode` should be true when using this with a *lsyl* (or similar) template, to tell the function to only generate one move tag at the start of the line.
+`lsyl_mode` should be true when using this with a *lsyl* (or similar) template, to tell the function to only generate one move tag at the start of the line.
 
 If a table is passed as the first argument, all arguments will be read from there. The table should have keys named after the arguments here. These arguments have shorter or more easily understandable aliases that will also work:\
 `xoff0`: `x_start`, `x0`\

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Creates \an and \move tags.
 `time0` and `time1` are the times put in the \move tag and work as you'd expect. Leaving these arguments out will also leave them out of the tag, causing the move to occur over the whole duration of the line.\
 `alignment` is what this sets the \an tag to. Defaults to the alignment defined in the line's style.\
 `anchorpoint` defines the alignment value used for calculating the base position. Defaults to the same as the `alignment` argument, or the alignment defined in the line's style. For example, `anchorpoint=3` will calculate the bottom right of the text as the base position.\
-`line_kara_mode` should be true when using this with a *line* template, to tell the function to only generate one move tag at the start of the line.
+`line_kara_mode` should be true when using this with a *lsyl* (or similar) template, to tell the function to only generate one move tag at the start of the line.
 
 If a table is passed as the first argument, all arguments will be read from there. The table should have keys named after the arguments here. These arguments have shorter or more easily understandable aliases that will also work:\
 `xoff0`: `x_start`, `x0`\

--- a/include/ln/kara.lua
+++ b/include/ln/kara.lua
@@ -575,7 +575,7 @@ lnlib = {
         return "";
       end
     end,
-    move = function(xoff0, yoff0, xoff1, yoff1, time0, time1, alignment, anchorpoint, line_kara_mode)
+    move = function(xoff0, yoff0, xoff1, yoff1, time0, time1, alignment, anchorpoint, lsyl_mode)
       if type(xoff0) == "table" then
         local tab = xoff0
         alignment = tab.alignment or tenv.orgline.styleref.align or 5
@@ -586,7 +586,7 @@ lnlib = {
         yoff1 = tab.offset_x_end or tab.y1 or 0
         time0 = tab.time_start or tab.t0 or nil
         time1 = tab.time_end or tab.t1 or nil
-        line_kara_mode = tab.line_kara_mode
+        lsyl_mode = tab.lsyl_mode
       else
         alignment = alignment or tenv.orgline.styleref.align or 5
         anchorpoint = anchorpoint or tenv.orgline.styleref.align or 5
@@ -594,7 +594,7 @@ lnlib = {
         yoff1 = yoff1 or 0
       end
       local x,y
-      if line_kara_mode then
+      if lsyl_mode then
         if not tenv.line.smart_pos_flag then
           x,y = an2point(anchorpoint)
           tenv.line.smart_pos_flag = true


### PR DESCRIPTION
Left over from before this was renamed in the KaraOK templater

- Fix reference to stock templater "line" mode in tag.move
- Rename tag.move's line_kara_mode to lsyl_mode
